### PR TITLE
Remove unused branch from workflow

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/build-docker-image # Temporary branch for testing purposes
 
 jobs:
   build:


### PR DESCRIPTION
This branch was used for the sake of implementing the workflow for building a Docker image. Now that the workflow is implemented, the branch is no longer needed.

This PR addresses what is being discussed in #4 